### PR TITLE
[bug] server tabs api returns tab.id - tests updated to reflect change [Closes #159]

### DIFF
--- a/modules/core/server/controllers/tabs.controller.server.js
+++ b/modules/core/server/controllers/tabs.controller.server.js
@@ -174,6 +174,7 @@ function getTabs (req, res) {
     tabs.forEach(function (tab) {
       var tempTab = {};
       tempTab.title = tab.title;
+      tempTab.id = tab.id;
       tempTab.uisref = tab.uisref;
       tempTab.visibleRoles = [];
       tab.Roles.forEach(function (role) {

--- a/modules/core/tests/server/tabs.test.server.js
+++ b/modules/core/tests/server/tabs.test.server.js
@@ -89,6 +89,7 @@ describe('/api/core/tabs', function () {
         } else {
           expect(res.body.title).toEqual(tab.title);
           expect(res.body.uisref).toEqual(tab.uisref);
+          expect(res.body.id).toEqual(1);
           done();
         }
       });
@@ -142,6 +143,7 @@ describe('/api/core/tabs', function () {
           } else {
             expect(res.body.title).toEqual(tab.title);
             expect(res.body.uisref).toEqual(tab.uisref);
+            expect(res.body.id).toEqual(savedTab.id);
             done();
           }
         });
@@ -155,6 +157,7 @@ describe('/api/core/tabs', function () {
         .end(function (err, res) {
           expect(res.body.title).toEqual(tab.title);
           expect(res.body.uisref).toEqual(tab.uisref);
+          expect(res.body.id).toEqual(savedTab.id);
           if(err) {
             done.fail(err);
           } else {
@@ -182,6 +185,7 @@ describe('/api/core/tabs', function () {
                 } else {
                   expect(res.body.title).toEqual('Some New Tab Title');
                   expect(res.body.uisref).toEqual(tab.uisref);
+                  expect(res.body.id).toEqual(savedTab.id);
                   done();
                 }
               });


### PR DESCRIPTION
- This solves the issue. Taken the following actions:
- [x] updated the processTabsAndSend function
- [x] updated tabs tests server side
