### PR TITLE
[feat] Pages view goes inside a card

### DIFF
--- a/modules/core/client/views/page.view.client.html
+++ b/modules/core/client/views/page.view.client.html
@@ -1,1 +1,5 @@
+<md-card>
+<md-card-content>
 <div layout-padding ng-bind-html="vm.content"></div>
+</md-card-content>
+</md-card>


### PR DESCRIPTION
This wraps a card around pages.
The main goal is for better structure of the pages (otherwise the content has no padding and goes to the left).
There are other ways to address this problem but I'm suggesting this one as it's super simple.

screenshot after change:
<img width="1266" alt="screen shot 2015-09-18 at 16 25 47" src="https://cloud.githubusercontent.com/assets/9615348/9973088/f26a6fa4-5e21-11e5-9869-99aa867d59a5.png">

screenshot before change:
<img width="1258" alt="screen shot 2015-09-18 at 16 26 10" src="https://cloud.githubusercontent.com/assets/9615348/9973089/0054bdb8-5e22-11e5-94be-6b948d8c20d4.png">
